### PR TITLE
Add Raspberry Pi UI stack and filesystem logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ I've had Deep-Wiki index my documentation. It did a mostly okay job. You can rea
 - Simultaneous current and voltage measurement abilities (requires a Hall sensor-based ammeter module). 
 - Data logging for current and voltage, with customizable triggers to autolog both.
 
+## Raspberry Pi user interface
+
+The repository now includes a Raspberry Pi-friendly interface that mirrors the firmware display and logging features. The UI is written in Python using Tkinter so it ships with Raspberry Pi OS and can run directly on the framebuffer or under X11. To start the dashboard with the built-in demo generator run:
+
+```
+python3 -m raspi_port.app
+```
+
+In deployment the measurement host should feed real readings to the `MicroDmmApp` class instead of the demo thread. The window presents the same information rendered by `updateDisplay()`—live voltage or resistance with min/max tracking, current when enabled, the active mode, timestamps, delta/null information, and log counters. Interaction hotkeys replace the touch panel:
+
+| Function | Touch color | Hotkey | Description |
+| --- | --- | --- | --- |
+| Mode cycle | Red | `M` | Advances through the measurement modes. |
+| Manual log | Green | `L` | Appends the most recent sample buffer to `~/micro_dmm_logs/data.csv`. |
+| Auto log export | – | `A` | Writes the auto-log buffer to `~/micro_dmm_logs/data_autologged.csv`. |
+| Min/Max reset | Blue | `Z` | Clears the stored extrema, just like tapping “Min/Max”. |
+| Type/Δ | Yellow | `T` | In *Type* mode it writes the displayed value to `typed_entries.txt`; otherwise it arms the delta/null workflow. |
+
+On a Raspberry Pi you can optionally map these controls to hardware buttons by defining a `MICRO_DMM_GPIO` environment variable before launching the program. The value is a comma-separated list such as `mode=5,manual_log=6,auto_log=13,minmax=19,type=26`. Each entry binds a GPIO pin (using `gpiozero.Button`) to the corresponding action.
+
+All log exports stay on the Pi’s filesystem under `~/micro_dmm_logs/`. The CSV layouts match the firmware’s `logCurrentData()` and `autologArraysToCSV()` routines so downstream tooling continues to work. The `typed_entries.txt` file replaces the USB keyboard emulator and captures the same formatted text that would have been “typed” into a host PC, while also echoing it to stdout for quick clipboard-style use.
+
 I have a long and detailed write-up of the circuitry design on my personal website: https://www.oihdesigns.com/arduino-multimeter-project
 
 There are a couple videos here:

--- a/raspi_port/app.py
+++ b/raspi_port/app.py
@@ -1,0 +1,306 @@
+"""Tkinter-based Raspberry Pi UI for the Micro-DMM."""
+from __future__ import annotations
+
+import math
+import threading
+import time
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Optional
+
+import tkinter as tk
+from tkinter import ttk
+
+from .data_model import (
+    MeasurementState,
+    format_resistance_value,
+    format_time,
+    format_voltage_value,
+)
+from .logging import PiLogger
+
+try:
+    from gpiozero import Button  # type: ignore
+except Exception:  # pragma: no cover - gpiozero is optional on dev hosts
+    Button = None
+
+
+@dataclass
+class ButtonMapping:
+    label: str
+    callback: Callable[[], None]
+    hotkey: str
+    gpio_pin: Optional[int] = None
+
+
+MODES: Iterable[str] = (
+    "Default",
+    "Voltmeter",
+    "VAC",
+    "Type",
+    "Low",
+    "AltUnits",
+    "High R",
+    "rPlotMode",
+    "Charging",
+)
+
+
+class MicroDmmApp:
+    """UI controller for the Raspberry Pi port."""
+
+    def __init__(
+        self,
+        root: tk.Tk,
+        state: Optional[MeasurementState] = None,
+        logger: Optional[PiLogger] = None,
+        gpio_pins: Optional[Dict[str, int]] = None,
+    ) -> None:
+        self.root = root
+        self.state = state or MeasurementState()
+        self.logger = logger or PiLogger()
+        self.mode_cycle = list(MODES)
+        self.mode_index = self.mode_cycle.index(self.state.current_mode) if self.state.current_mode in self.mode_cycle else 0
+
+        self._build_ui()
+        if gpio_pins:
+            for key, pin in gpio_pins.items():
+                if key in self.button_mappings:
+                    self.button_mappings[key].gpio_pin = pin
+        self._install_keyboard_shortcuts()
+        self._install_gpio_buttons()
+
+        self.update_display()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    def _build_ui(self) -> None:
+        self.root.title("Micro-DMM (Raspberry Pi)")
+        self.root.configure(padx=16, pady=16)
+
+        header = ttk.Label(self.root, text="Measurement", font=("TkDefaultFont", 24, "bold"))
+        header.grid(row=0, column=0, columnspan=2, sticky="w")
+
+        self.primary_value = ttk.Label(self.root, font=("TkDefaultFont", 32, "bold"))
+        self.primary_value.grid(row=1, column=0, sticky="w")
+
+        self.primary_suffix = ttk.Label(self.root, font=("TkDefaultFont", 16))
+        self.primary_suffix.grid(row=1, column=1, sticky="w")
+
+        self.secondary_info = ttk.Label(self.root, font=("TkDefaultFont", 14))
+        self.secondary_info.grid(row=2, column=0, columnspan=2, sticky="w")
+
+        ttk.Separator(self.root, orient="horizontal").grid(row=3, column=0, columnspan=2, sticky="ew", pady=12)
+
+        self.mode_label = ttk.Label(self.root, font=("TkDefaultFont", 14))
+        self.mode_label.grid(row=4, column=0, sticky="w")
+
+        self.time_label = ttk.Label(self.root, font=("TkDefaultFont", 14))
+        self.time_label.grid(row=4, column=1, sticky="w")
+
+        self.current_label = ttk.Label(self.root, font=("TkDefaultFont", 14))
+        self.current_label.grid(row=5, column=0, columnspan=2, sticky="w")
+
+        self.minmax_label = ttk.Label(self.root, font=("TkDefaultFont", 12))
+        self.minmax_label.grid(row=6, column=0, columnspan=2, sticky="w")
+
+        self.logging_label = ttk.Label(self.root, font=("TkDefaultFont", 12))
+        self.logging_label.grid(row=7, column=0, columnspan=2, sticky="w")
+
+        ttk.Separator(self.root, orient="horizontal").grid(row=8, column=0, columnspan=2, sticky="ew", pady=12)
+
+        self.button_frame = ttk.Frame(self.root)
+        self.button_frame.grid(row=9, column=0, columnspan=2, sticky="ew")
+
+        self.button_mappings: Dict[str, ButtonMapping] = {
+            "mode": ButtonMapping("Mode", self.cycle_mode, "m"),
+            "manual_log": ButtonMapping("Manual Log", self.request_manual_log, "l"),
+            "auto_log": ButtonMapping("Auto Log", self.request_auto_log, "a"),
+            "minmax": ButtonMapping("Reset Min/Max", self.reset_min_max, "z"),
+            "type": ButtonMapping("Type/Δ", self.trigger_type_action, "t"),
+        }
+
+        for column, mapping in enumerate(self.button_mappings.values()):
+            btn = ttk.Button(self.button_frame, text=f"{mapping.label} ({mapping.hotkey.upper()})", command=mapping.callback)
+            btn.grid(row=0, column=column, padx=4, pady=4, sticky="ew")
+            self.button_frame.columnconfigure(column, weight=1)
+
+    def _install_keyboard_shortcuts(self) -> None:
+        for mapping in self.button_mappings.values():
+            self.root.bind(f"<{mapping.hotkey}>", lambda event, cb=mapping.callback: cb())
+            self.root.bind(f"<{mapping.hotkey.upper()}>", lambda event, cb=mapping.callback: cb())
+
+    def _install_gpio_buttons(self) -> None:
+        if Button is None:
+            return
+        for mapping in self.button_mappings.values():
+            if mapping.gpio_pin is None:
+                continue
+            button = Button(mapping.gpio_pin)
+            button.when_pressed = mapping.callback
+
+    # ------------------------------------------------------------------
+    # State update API
+    def update_state(self, **kwargs: float | str | bool) -> None:
+        for key, value in kwargs.items():
+            if hasattr(self.state, key):
+                setattr(self.state, key, value)
+        self.update_display()
+
+    def ingest_measurement(self, voltage: float, resistance: float, current: float, timestamp_ms: Optional[float] = None) -> None:
+        timestamp_ms = timestamp_ms if timestamp_ms is not None else time.time() * 1000.0
+        seconds = timestamp_ms / 1000.0
+        self.state.new_voltage = voltage
+        self.state.display_resistance = resistance
+        self.state.current_reading = current
+        self.state.record_current_sample(voltage, seconds, current)
+        self.state.update_timestamps(timestamp_ms)
+        self.state.update_extrema(timestamp_ms)
+        self.update_display()
+
+    # ------------------------------------------------------------------
+    # Action handlers
+    def cycle_mode(self) -> None:
+        self.mode_index = (self.mode_index + 1) % len(self.mode_cycle)
+        self.state.current_mode = self.mode_cycle[self.mode_index]
+        self.update_display()
+
+    def request_manual_log(self) -> None:
+        if self.state.manual_log.sample_count == 0:
+            return
+        self.state.log_end_time = self.state.manual_log.timestamps[0] + self.state.log_start_time
+        self.logger.write_manual_log(self.state)
+        self.state.manual_log_count += 1
+        self.update_display()
+
+    def request_auto_log(self) -> None:
+        if self.state.auto_log.sample_count == 0:
+            return
+        self.logger.write_auto_log(self.state)
+        self.state.auto_log_count += 1
+        self.update_display()
+
+    def reset_min_max(self) -> None:
+        self.state.low_voltage = self.state.high_voltage = self.state.new_voltage
+        self.state.low_resistance = self.state.high_resistance = self.state.display_resistance
+        self.state.current_low = self.state.current_high = self.state.current_reading
+        self.state.time_at_min_voltage = self.state.time_at_max_voltage = format_time(self.state.last_update_ms)
+        self.state.time_at_min_resistance = self.state.time_at_max_resistance = format_time(self.state.last_update_ms)
+        self.state.time_at_min_current = self.state.time_at_max_current = format_time(self.state.last_update_ms)
+        self.logger.emit_keyboard_line("Min/Max reset")
+        self.update_display()
+
+    def trigger_type_action(self) -> None:
+        if self.state.current_mode == "Type":
+            primary_value, _, digits = format_voltage_value(self.state.new_voltage) if self.state.voltage_display else format_resistance_value(self.state.display_resistance)
+            base_value = self.state.new_voltage if self.state.voltage_display else self.state.display_resistance
+            text = f"{base_value:.{digits}f}"
+            self.logger.emit_keyboard_line(text)
+        else:
+            if self.state.voltage_display:
+                self.state.delta_voltage = self.state.new_voltage
+            else:
+                self.state.zero_offset_res = 0.0 if math.isclose(self.state.zero_offset_res, 0.0, abs_tol=1e-6) else self.state.display_resistance
+        self.update_display()
+
+    # ------------------------------------------------------------------
+    def update_display(self) -> None:
+        if self.state.last_update_ms == 0:
+            self.primary_value.configure(text="--")
+            self.primary_suffix.configure(text="")
+            self.secondary_info.configure(text="Waiting for data…")
+        else:
+            primary_value, suffix, digits = (
+                format_voltage_value(self.state.select_voltage_for_display())
+                if self.state.voltage_display
+                else format_resistance_value(self.state.display_resistance)
+            )
+            primary_text = f"{primary_value:.{digits}f}"
+            self.primary_value.configure(text=primary_text)
+            unit = "V" if self.state.voltage_display else "Ω"
+            self.primary_suffix.configure(text=f" {suffix}{unit}")
+
+            if self.state.voltage_display and not math.isinf(self.state.low_voltage):
+                low_val, low_suffix, low_digits = format_voltage_value(self.state.low_voltage)
+                high_val, high_suffix, high_digits = format_voltage_value(self.state.high_voltage)
+                secondary = (
+                    f"Min {low_val:.{low_digits}f}{low_suffix}  ({self.state.time_at_min_voltage})\n"
+                    f"Max {high_val:.{high_digits}f}{high_suffix}  ({self.state.time_at_max_voltage})"
+                )
+            elif not self.state.voltage_display and not math.isinf(self.state.low_resistance):
+                low_val, low_suffix, low_digits = format_resistance_value(self.state.low_resistance)
+                high_val, high_suffix, high_digits = format_resistance_value(self.state.high_resistance)
+                secondary = (
+                    f"Min {low_val:.{low_digits}f}{low_suffix}Ω  ({self.state.time_at_min_resistance})\n"
+                    f"Max {high_val:.{high_digits}f}{high_suffix}Ω  ({self.state.time_at_max_resistance})"
+                )
+            else:
+                secondary = "Gathering min/max data…"
+            self.secondary_info.configure(text=secondary)
+
+        current_text = "Current disabled"
+        if self.state.current_enabled and not math.isinf(self.state.current_low):
+            unit = "A" if self.state.current_range_high else "mA"
+            value = self.state.current_reading if self.state.current_range_high else self.state.current_reading * 1000.0
+            digits = 2 if self.state.current_range_high else 3
+            current_low = self.state.current_low if self.state.current_range_high else self.state.current_low * 1000.0
+            current_high = self.state.current_high if self.state.current_range_high else self.state.current_high * 1000.0
+            current_text = (
+                f"Current: {value:.{digits}f} {unit} (min {current_low:.3f}, max {current_high:.3f})"
+            )
+        self.current_label.configure(text=current_text)
+
+        self.mode_label.configure(text=f"Mode: {self.state.current_mode}")
+        self.time_label.configure(text=f"Clock: {self.state.formatted_time()}")
+
+        logging = f"Logging: {'USB' if self.state.log_mode_enabled else 'Off'} | Manual {self.state.manual_log_count} | Auto {self.state.auto_log_count}"
+        self.logging_label.configure(text=logging)
+
+        minmax = ""
+        if self.state.delta_voltage:
+            minmax += f"ΔV ref: {self.state.delta_voltage:.3f} V\n"
+        if self.state.zero_offset_res:
+            minmax += f"Null offset: {self.state.zero_offset_res * 1000:.1f} mΩ"
+        self.minmax_label.configure(text=minmax)
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def _demo_data(app: MicroDmmApp) -> None:
+    start = time.time()
+    app.update_state(voltage_display=True, current_enabled=True, current_range_high=False, log_mode_enabled=True)
+    while True:
+        elapsed = time.time() - start
+        voltage = math.sin(elapsed / 3.0) * 2.0 + 5.0
+        resistance = 1000.0 + math.sin(elapsed / 5.0) * 50
+        current = 0.01 + math.cos(elapsed / 4.0) * 0.002
+        timestamp_ms = time.time() * 1000.0
+        app.state.queue_auto_sample(voltage, elapsed, current)
+        app.ingest_measurement(voltage, resistance, current, timestamp_ms=timestamp_ms)
+        time.sleep(1.0)
+
+
+def main() -> None:
+    root = tk.Tk()
+    gpio_config: Dict[str, int] = {}
+    env = os.getenv("MICRO_DMM_GPIO", "").strip()
+    if env:
+        for token in env.split(','):
+            if '=' not in token:
+                continue
+            key, value = token.split('=', 1)
+            key = key.strip()
+            try:
+                gpio_config[key] = int(value)
+            except ValueError:
+                continue
+    app = MicroDmmApp(root, gpio_pins=gpio_config or None)
+    demo_thread = threading.Thread(target=_demo_data, args=(app,), daemon=True)
+    demo_thread.start()
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/raspi_port/data_model.py
+++ b/raspi_port/data_model.py
@@ -1,0 +1,204 @@
+"""Data model and formatting helpers for the Raspberry Pi Micro-DMM UI."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Iterable, Tuple
+
+LOG_SIZE = 100
+NUM_AUTO_VALUES = 32
+
+
+def format_voltage_value(value: float) -> Tuple[float, str, int]:
+    """Match the Arduino formatting used by ``formatVoltageValue``.
+
+    Returns a tuple containing the scaled value, suffix ("" or "m"),
+    and the number of digits to show after the decimal point.
+    """
+    if abs(value) < 0.9:
+        out_value = value * 1000.0
+        suffix = "m"
+        digits = 0
+    else:
+        out_value = value
+        suffix = ""
+        digits = 2 if abs(value) > 11.0 else 3
+    return out_value, suffix, digits
+
+
+def format_resistance_value(value: float) -> Tuple[float, str, int]:
+    """Port of ``formatResistanceValue`` from the firmware."""
+    if value > 90_000_000.0:
+        return value / 1_000_000.0, "M", 1
+    if value > 9_000_000.0:
+        return value / 1_000_000.0, "M", 2
+    if value > 900_000.0:
+        return value / 1_000_000.0, "M", 3
+    if value > 900.0:
+        digits = 3 if value > 90_000.0 else 4
+        return value / 1_000.0, "k", digits
+    if value < 0.9:
+        digits = 1 if value < 0.09 else 2
+        return value * 1000.0, "m", digits
+    if value >= 100.0:
+        digits = 2
+    elif value < 9.5:
+        digits = 4
+    else:
+        digits = 3
+    return value, "", digits
+
+
+def format_time(milliseconds: float) -> str:
+    total_seconds = int(milliseconds // 1000)
+    minutes, seconds = divmod(total_seconds, 60)
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+@dataclass
+class ManualLog:
+    voltages: Deque[float] = field(default_factory=lambda: deque([0.0] * LOG_SIZE, maxlen=LOG_SIZE))
+    currents: Deque[float] = field(default_factory=lambda: deque([0.0] * LOG_SIZE, maxlen=LOG_SIZE))
+    timestamps: Deque[float] = field(default_factory=lambda: deque([0.0] * LOG_SIZE, maxlen=LOG_SIZE))
+    sample_count: int = 0
+
+    def add_entry(self, voltage: float, time_sec: float, current: float, reference_start: float) -> None:
+        relative_time = time_sec - reference_start
+        self.voltages.appendleft(voltage)
+        self.currents.appendleft(current)
+        self.timestamps.appendleft(relative_time)
+        self.sample_count = min(self.sample_count + 1, LOG_SIZE)
+
+    def as_rows(self, include_current: bool, start_time: float = 0.0) -> Iterable[Iterable[float]]:
+        yield list(self.voltages)
+        if include_current:
+            yield list(self.currents)
+        yield [t - start_time for t in self.timestamps]
+
+
+@dataclass
+class AutoLog:
+    voltages: Deque[float] = field(default_factory=lambda: deque([0.0] * NUM_AUTO_VALUES, maxlen=NUM_AUTO_VALUES))
+    currents: Deque[float] = field(default_factory=lambda: deque([0.0] * NUM_AUTO_VALUES, maxlen=NUM_AUTO_VALUES))
+    timestamps: Deque[float] = field(default_factory=lambda: deque([0.0] * NUM_AUTO_VALUES, maxlen=NUM_AUTO_VALUES))
+    sample_count: int = 0
+
+    def push(self, voltage: float, timestamp: float, current: float) -> None:
+        self.voltages.appendleft(voltage)
+        self.timestamps.appendleft(timestamp)
+        self.currents.appendleft(current)
+        self.sample_count = min(self.sample_count + 1, NUM_AUTO_VALUES)
+
+    def as_rows(self, include_current: bool) -> Iterable[Iterable[float]]:
+        yield list(self.voltages)
+        if include_current:
+            yield list(self.currents)
+        yield list(self.timestamps)
+
+
+@dataclass
+class MeasurementState:
+    """Container for measurements mirrored from the firmware."""
+
+    new_voltage: float = 0.0
+    median_voltage: float = 0.0
+    median_voltage_step: float = 0.0
+    low_voltage: float = float("inf")
+    high_voltage: float = float("-inf")
+    time_at_min_voltage: str = "00:00"
+    time_at_max_voltage: str = "00:00"
+    display_resistance: float = 0.0
+    low_resistance: float = float("inf")
+    high_resistance: float = float("-inf")
+    time_at_min_resistance: str = "00:00"
+    time_at_max_resistance: str = "00:00"
+    current_reading: float = 0.0
+    current_enabled: bool = False
+    current_range_high: bool = False
+    current_low: float = float("inf")
+    current_high: float = float("-inf")
+    time_at_min_current: str = "00:00"
+    time_at_max_current: str = "00:00"
+    precise_mode: bool = False
+    delta_mode: bool = False
+    delta_voltage: float = 0.0
+    zero_offset_res: float = 0.0
+    min_max_display: bool = False
+
+    current_mode: str = "Default"
+    voltage_display: bool = True
+    log_mode_enabled: bool = False
+    manual_log_count: int = 0
+    auto_log_count: int = 0
+
+    log_start_time: float = 0.0
+    log_end_time: float = 0.0
+    auto_log_start_time: float = 0.0
+
+    last_update_ms: float = 0.0
+
+    manual_log: ManualLog = field(default_factory=ManualLog)
+    auto_log: AutoLog = field(default_factory=AutoLog)
+
+    def select_voltage_for_display(self) -> float:
+        if not self.precise_mode:
+            if abs(self.median_voltage_step) > 0.5:
+                return self.new_voltage
+            return self.median_voltage
+        return self.new_voltage
+
+    def record_current_sample(self, voltage: float, time_sec: float, current: float) -> None:
+        if self.manual_log.sample_count == 0:
+            self.log_start_time = time_sec
+        self.manual_log.add_entry(voltage, time_sec, current, self.log_start_time)
+
+    def queue_auto_sample(self, voltage_at_peak: float, timestamp: float, current: float) -> None:
+        if self.auto_log.sample_count == 0:
+            self.auto_log_start_time = timestamp
+        self.auto_log.push(voltage_at_peak, timestamp, current)
+
+    def update_timestamps(self, current_millis: float) -> None:
+        self.last_update_ms = current_millis
+
+    def update_extrema(self, timestamp_ms: float) -> None:
+        time_string = format_time(timestamp_ms)
+        if self.new_voltage < self.low_voltage:
+            self.low_voltage = self.new_voltage
+            self.time_at_min_voltage = time_string
+        if self.new_voltage > self.high_voltage:
+            self.high_voltage = self.new_voltage
+            self.time_at_max_voltage = time_string
+
+        if self.display_resistance < self.low_resistance:
+            self.low_resistance = self.display_resistance
+            self.time_at_min_resistance = time_string
+        if self.display_resistance > self.high_resistance:
+            self.high_resistance = self.display_resistance
+            self.time_at_max_resistance = time_string
+
+        if self.current_reading < self.current_low:
+            self.current_low = self.current_reading
+            self.time_at_min_current = time_string
+        if self.current_reading > self.current_high:
+            self.current_high = self.current_reading
+            self.time_at_max_current = time_string
+
+    def display_values(self) -> dict:
+        voltage_to_display = self.select_voltage_for_display()
+        voltage_fmt = format_voltage_value(voltage_to_display)
+        voltage_low_fmt = format_voltage_value(self.low_voltage)
+        voltage_high_fmt = format_voltage_value(self.high_voltage)
+        resistance_fmt = format_resistance_value(self.display_resistance)
+        resistance_low_fmt = format_resistance_value(self.low_resistance)
+        resistance_high_fmt = format_resistance_value(self.high_resistance)
+        return {
+            "voltage": voltage_fmt,
+            "voltage_low": voltage_low_fmt,
+            "voltage_high": voltage_high_fmt,
+            "resistance": resistance_fmt,
+            "resistance_low": resistance_low_fmt,
+            "resistance_high": resistance_high_fmt,
+        }
+
+    def formatted_time(self) -> str:
+        return format_time(self.last_update_ms)

--- a/raspi_port/logging.py
+++ b/raspi_port/logging.py
@@ -1,0 +1,41 @@
+"""Logging helpers for the Raspberry Pi Micro-DMM port."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from .data_model import MeasurementState
+
+
+class PiLogger:
+    """Persist CSV logs on the Raspberry Pi filesystem."""
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self.base_dir = base_dir or Path.home() / "micro_dmm_logs"
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.manual_path = self.base_dir / "data.csv"
+        self.auto_path = self.base_dir / "data_autologged.csv"
+        self.keyboard_path = self.base_dir / "typed_entries.txt"
+
+    def _write_rows(self, path: Path, header: str, end_time: float, rows: Iterable[Iterable[float]]) -> None:
+        with path.open("a", newline="") as fp:
+            writer = csv.writer(fp)
+            writer.writerow([header, f"{end_time:.2f}"])
+            for row in rows:
+                writer.writerow([f"{value:.3f}" for value in row])
+
+    def write_manual_log(self, state: MeasurementState) -> None:
+        rows = state.manual_log.as_rows(include_current=state.current_enabled)
+        self._write_rows(self.manual_path, "DataLog End Time", state.log_end_time, rows)
+
+    def write_auto_log(self, state: MeasurementState) -> None:
+        rows = state.auto_log.as_rows(include_current=state.current_enabled, start_time=state.auto_log_start_time)
+        end_time = state.auto_log.timestamps[0] if state.auto_log.sample_count else 0.0
+        self._write_rows(self.auto_path, "DataLogged End Time", end_time, rows)
+
+    def emit_keyboard_line(self, text: str) -> None:
+        with self.keyboard_path.open("a", encoding="utf-8") as fp:
+            fp.write(text + "\n")
+        print(text)
+


### PR DESCRIPTION
## Summary
- add a Tkinter-based Raspberry Pi UI that mirrors the firmware display state and touch interactions via hotkeys, optional GPIO buttons, and a demo data generator
- port the firmware formatting and logging helpers into Python so manual and auto CSV exports plus keyboard typing land on the Pi filesystem with the original layouts
- document the new Raspberry Pi workflow, filesystem locations, and control mappings in the README

## Testing
- python3 -m compileall raspi_port

------
https://chatgpt.com/codex/tasks/task_e_68d7342b24c88327b2fe72384e7410e8