### PR TITLE
Allow running run_pi.py as a standalone script

### DIFF
--- a/rpi_port/README.md
+++ b/rpi_port/README.md
@@ -42,6 +42,16 @@ python3 -m rpi_port.run_pi \
     --gpio-button mode=5 --gpio-button manual_log=6
 ```
 
+If you prefer a single-file style invocation, the launcher now also works when
+executed directly:
+
+```bash
+python3 rpi_port/run_pi.py --drdy-pin 22 --range-pin 23
+```
+
+Both commands expect the `rpi_port` folder to stay intact, since the Tk UI,
+ADS1256 backend, and logging helpers live alongside `run_pi.py`.
+
 The options are all optional:
 
 * `--drdy-pin` hooks the ADS1256 **DRDY** line so conversions are synchronised.【F:rpi_port/run_pi.py†L107-L133】

--- a/rpi_port/run_pi.py
+++ b/rpi_port/run_pi.py
@@ -2,13 +2,27 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import signal
 import sys
 import threading
 import time
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional
+
+# ---------------------------------------------------------------------------
+# Stand-alone execution support
+# ---------------------------------------------------------------------------
+if __package__ in (None, ""):
+    # Allow ``python rpi_port/run_pi.py`` to work by emulating package imports.
+    package_root = Path(__file__).resolve().parent
+    parent_dir = str(package_root.parent)
+    package_dir = str(package_root)
+    sys.path.insert(0, parent_dir)
+    if package_dir in sys.path:
+        sys.path.remove(package_dir)
+    __package__ = package_root.name
+
+import logging
 
 try:  # pragma: no cover - optional hardware dependencies
     from gpiozero import DigitalInputDevice, LED


### PR DESCRIPTION
## Summary
- add standalone execution guard to rpi_port/run_pi.py so it can be launched directly
- document the new invocation option in the Raspberry Pi runtime README

## Testing
- python rpi_port/run_pi.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d744c07cc08327ba88813171b76b8d