### PR TITLE
Add debug display mode and runtime clock to Pi UI

### DIFF
--- a/rpi_port/data_model.py
+++ b/rpi_port/data_model.py
@@ -108,6 +108,7 @@ class MeasurementState:
     time_at_min_voltage: str = "00:00"
     time_at_max_voltage: str = "00:00"
     display_resistance: float = 0.0
+    ohms_voltage: float = 0.0
     low_resistance: float = float("inf")
     high_resistance: float = float("-inf")
     time_at_min_resistance: str = "00:00"
@@ -125,7 +126,7 @@ class MeasurementState:
     zero_offset_res: float = 0.0
     min_max_display: bool = False
 
-    current_mode: str = "Default"
+    current_mode: str = "Debug"
     voltage_display: bool = True
     log_mode_enabled: bool = False
     manual_log_count: int = 0

--- a/rpi_port/run_pi.py
+++ b/rpi_port/run_pi.py
@@ -194,6 +194,7 @@ class MeasurementService:
             resistance=resistance.value,
             current=current.value,
             timestamp_ms=timestamp_ms,
+            ohms_voltage=resistance.ohms_voltage,
         )
 
 


### PR DESCRIPTION
## Summary
- add a default Debug mode that shows voltage and resistance side-by-side with the sensed ohms voltage in the measurement header
- expose storage for the resistance sense voltage and plumb it through the ingestion pipeline
- replace the clock label with a continuously updating runtime counter in hh:mm:ss

## Testing
- python -m compileall rpi_port

------
https://chatgpt.com/codex/tasks/task_e_68d83f17e128832796bb93e6005943c5