### PR TITLE
Expose ADC configuration controls in Tk UI

### DIFF
--- a/rpi_port/README.md
+++ b/rpi_port/README.md
@@ -63,6 +63,8 @@ The options are all optional:
 
 The script spawns a background thread that continuously polls the ADS1256 backend and feeds the Tk UI with calibrated voltage, resistance, and current readings.【F:rpi_port/run_pi.py†L90-L170】  Logging controls mirror the original firmware: pressing the UI buttons (or their GPIO equivalents) writes CSV files under `~/micro_dmm_logs` unless you override the directory via `--log-dir`.【F:rpi_port/logging.py†L1-L33】【F:rpi_port/app.py†L129-L188】
 
+The lower portion of the window now exposes the ADC configuration and calibration tools that used to live in the hidden debug layout. You can switch the gain between automatic and manual (and pick a specific PGA gain when manual is enabled), change the ADS1256 sample rate, toggle the input buffer, and perform offset/scale calibration of the voltage channel directly from the main screen.【F:rpi_port/app.py†L205-L317】
+
 ## 4. Shutting down
 
 The program installs SIGINT/SIGTERM handlers so `Ctrl+C` or a systemd stop cleanly closes the ADS1256 SPI device, releases GPIO resources, and exits the Tk main loop.【F:rpi_port/run_pi.py†L190-L238】

--- a/rpi_port/app.py
+++ b/rpi_port/app.py
@@ -218,18 +218,17 @@ class MicroDmmApp:
             self.button_frame.columnconfigure(column, weight=1)
 
 
-        self.debug_controls_frame = ttk.LabelFrame(parent, text="Debug tools", padding=4)
-        self.debug_controls_frame.grid(row=10, column=0, columnspan=2, sticky="nsew", pady=(8, 0))
+        self.backend_controls_frame = ttk.LabelFrame(parent, text="ADC controls", padding=4)
+        self.backend_controls_frame.grid(row=10, column=0, columnspan=2, sticky="nsew", pady=(8, 0))
         if hasattr(parent, "rowconfigure"):
             try:
                 parent.rowconfigure(10, weight=1)
             except tk.TclError:
                 pass
-        self.debug_controls_frame.grid_remove()
 
-        controls_container = ttk.Frame(self.debug_controls_frame)
+        controls_container = ttk.Frame(self.backend_controls_frame)
         controls_container.grid(row=0, column=0, sticky="nsew")
-        self.debug_controls_frame.columnconfigure(0, weight=1)
+        self.backend_controls_frame.columnconfigure(0, weight=1)
         controls_container.columnconfigure(0, weight=1)
 
         gain_frame = ttk.LabelFrame(controls_container, text="Gain", padding=4)
@@ -478,13 +477,11 @@ class MicroDmmApp:
         if enabled and not self._debug_visible:
             self.standard_display_frame.grid_remove()
             self.debug_display_frame.grid()
-            self.debug_controls_frame.grid()
 
             self._debug_visible = True
         elif not enabled and self._debug_visible:
             self.debug_display_frame.grid_remove()
             self.standard_display_frame.grid()
-            self.debug_controls_frame.grid_remove()
 
             self._debug_visible = False
 


### PR DESCRIPTION
## Summary
- keep the ADS1256 gain, sample rate, buffer, and calibration widgets visible in the Raspberry Pi UI
- document the newly surfaced controls in the runtime README

## Testing
- python -m compileall rpi_port

------
https://chatgpt.com/codex/tasks/task_e_68d916362b0c8327b170c739486699cc