### PR TITLE
Fix RMS buffer to store squared samples

### DIFF
--- a/FT232H Version/microDMM_FT232H.py
+++ b/FT232H Version/microDMM_FT232H.py
@@ -622,8 +622,7 @@ class MicroDMM:
         self._voltage_sq_sum -= old_sq
 
         self._voltage_buffer[idx] = voltage
-        diff = voltage - self._voltage_avg
-        squared = diff * diff
+        squared = voltage * voltage
         self._voltage_sq_buffer[idx] = squared
 
         self._voltage_sum += voltage


### PR DESCRIPTION
## Summary
- update the moving RMS buffer to store true squared voltage samples
- ensure step changes in DC level immediately reflect in the RMS calculation

## Testing
- python -m compileall 'FT232H Version/microDMM_FT232H.py'

------
https://chatgpt.com/codex/tasks/task_e_68e102f0f09c8327be295238158e4932