### PR TITLE
Calibrate ADS1256 after gain or rate changes

### DIFF
--- a/Raspberry Pi Project/ADS1256 GUI V3_triggering.py
+++ b/Raspberry Pi Project/ADS1256 GUI V3_triggering.py
@@ -27,6 +27,7 @@ CMD_SDATAC = 0x0F
 CMD_WREG = 0x50
 CMD_SYNC = 0xFC
 CMD_RESET = 0xFE
+CMD_SELFCAL = 0xF0
 
 DRATE_TABLE = {
     "30k SPS": 0xF0,
@@ -69,6 +70,7 @@ CHANNEL_MAP = [
 
 TRIGGER_MODES = ("Benchmark", "Multi")
 TRIGGER_SLOPES = ("Rising", "Falling")
+TRIGGER_POSITIONS = ("Start", "Mid", "End")
 
 ALL_GPIO_PINS = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 16, 19, 20, 21, 24, 25, 26, 27]
 SPI_PINS = {8, 9, 10, 11}
@@ -118,6 +120,27 @@ def write_reg(reg: int, data: int) -> None:
     cs_high()
 
 
+def perform_self_calibration() -> None:
+    send_cmd(CMD_SDATAC)
+    send_cmd(CMD_SELFCAL)
+    wait_drdy()
+
+
+def request_calibration() -> None:
+    global pending_calibration
+    pending_calibration = True
+    if not is_capturing:
+        perform_self_calibration()
+        pending_calibration = False
+
+
+def run_pending_calibration() -> None:
+    global pending_calibration
+    if pending_calibration and not is_capturing:
+        perform_self_calibration()
+        pending_calibration = False
+
+
 def read_data() -> int:
     cs_low()
     spi.xfer2([CMD_RDATA])
@@ -147,6 +170,8 @@ def set_channel(p: int, n: int) -> None:
 # ---------------- ADC config ----------------
 
 current_gain = 1
+is_capturing = False
+pending_calibration = False
 
 
 def ads1256_init() -> None:
@@ -161,6 +186,7 @@ def ads1256_init() -> None:
     set_buffer(False)
     set_drate("30k SPS")
     set_gain("1x")
+    run_pending_calibration()
 
 
 def set_buffer(enable: bool) -> None:
@@ -171,6 +197,7 @@ def set_buffer(enable: bool) -> None:
 def set_drate(name: str) -> None:
     code = DRATE_TABLE.get(name, 0xF0)
     write_reg(0x03, code)
+    request_calibration()
 
 
 def set_gain(name: str) -> None:
@@ -178,13 +205,17 @@ def set_gain(name: str) -> None:
     gain_code = GAIN_TABLE.get(name, 0)
     current_gain = (1 << gain_code) if gain_code > 0 else 1
     write_reg(0x02, gain_code & 0x07)
+    request_calibration()
 
 
-def read_channel_raw(ch_index: int) -> int:
+def read_channel_raw(ch_index: int, *, fast: bool = False) -> int:
     set_channel(*CHANNEL_MAP[ch_index][1])
     send_cmd(CMD_SYNC)
     send_cmd(CMD_WAKEUP)
-    wait_drdy()
+    if fast:
+        wait_drdy_fast()
+    else:
+        wait_drdy()
     return read_data()
 
 
@@ -501,6 +532,7 @@ points_var = tk.StringVar(value="1000")
 trigger_level_var = tk.StringVar(value="0.0")
 trigger_mode_var = tk.StringVar(value=TRIGGER_MODES[0])
 trigger_slope_var = tk.StringVar(value=TRIGGER_SLOPES[0])
+trigger_position_var = tk.StringVar(value=TRIGGER_POSITIONS[0])
 
 channel_names = [c[0] for c in CHANNEL_MAP]
 trigger_channel_var = tk.StringVar(value=channel_names[0])
@@ -564,6 +596,21 @@ trigger_slope_combo = ttk.Combobox(
 trigger_slope_combo.grid(row=row_counter, column=1, sticky="w", padx=4, pady=4)
 row_counter += 1
 
+trigger_position_label = ttk.Label(
+    logger_frame, text="Trigger Position:", font=CHANNEL_FONT
+)
+trigger_position_label.grid(row=row_counter, column=0, sticky="w", padx=4, pady=4)
+
+trigger_position_combo = ttk.Combobox(
+    logger_frame,
+    textvariable=trigger_position_var,
+    values=list(TRIGGER_POSITIONS),
+    state="readonly",
+    width=14,
+)
+trigger_position_combo.grid(row=row_counter, column=1, sticky="w", padx=4, pady=4)
+row_counter += 1
+
 status_label = ttk.Label(logger_frame, textvariable=status_var, font=CHANNEL_FONT)
 status_label.grid(row=row_counter, column=0, columnspan=3, sticky="w", padx=4, pady=6)
 row_counter += 1
@@ -573,7 +620,6 @@ button_frame.grid(row=row_counter, column=0, columnspan=3, sticky="w", padx=4, p
 
 captured_data: dict[int, list[float]] | None = None
 timestamps: list[float] | None = None
-is_capturing = False
 update_job: str | None = None
 
 arm_button = tk.Button(button_frame, text="Arm Trigger", font=BUTTON_FONT)
@@ -654,6 +700,19 @@ def compute_trigger_value(ch_index: int, raw_value: int) -> float | None:
     if raw_var.get():
         return float(raw_value)
     return volts
+
+
+def compute_capture_values(ch_index: int, raw_value: int) -> tuple[float, float | None]:
+    volts = raw_to_volts(raw_value)
+    if dmm_math_var.get():
+        value, text = compute_dmm_value(ch_index, volts)
+        if text == "OVER":
+            return float("nan"), None
+        return value, value
+    if raw_var.get():
+        val = float(raw_value)
+        return val, val
+    return volts, volts
 
 
 def update_graph() -> None:
@@ -754,14 +813,43 @@ def run_benchmark_capture(
     threshold: float,
     slope: str,
     armed: bool,
+    position: str,
 ) -> tuple[dict[int, list[float]], list[float]]:
-    if armed:
-        wait_for_trigger(ch_index, threshold, slope)
-        status_var.set("Trigger detected - benchmarking...")
-    else:
-        status_var.set("Benchmark capture in progress...")
-
     set_channel(*CHANNEL_MAP[ch_index][1])
+
+    if not armed or position == "Start":
+        if armed:
+            wait_for_trigger(ch_index, threshold, slope)
+            status_var.set("Trigger detected - benchmarking...")
+        else:
+            status_var.set("Benchmark capture in progress...")
+
+        send_cmd(CMD_RDATAC)
+        wait_drdy_fast()
+
+        gc_was_enabled = gc.isenabled()
+        if gc_was_enabled:
+            gc.disable()
+
+        captured = {ch_index: [float("nan")] * n_points}
+        times = [0.0] * n_points
+        start = time.time()
+        try:
+            for idx in range(n_points):
+                wait_drdy_fast()
+                raw = read_data_raw_fast()
+                sample_value, _ = compute_capture_values(ch_index, raw)
+                captured[ch_index][idx] = sample_value
+                times[idx] = (time.time() - start) * 1000.0
+        finally:
+            if gc_was_enabled:
+                gc.enable()
+            send_cmd(CMD_SDATAC)
+        return captured, times
+
+    status_var.set(
+        f"Buffering for {position.lower()} trigger on {CHANNEL_MAP[ch_index][0]}"
+    )
     send_cmd(CMD_RDATAC)
     wait_drdy_fast()
 
@@ -769,64 +857,257 @@ def run_benchmark_capture(
     if gc_was_enabled:
         gc.disable()
 
-    captured = {ch_index: [float("nan")] * n_points}
-    times = [0.0] * n_points
-    start = time.time()
-    for idx in range(n_points):
-        wait_drdy_fast()
-        raw = read_data_raw_fast()
-        volts = raw_to_volts(raw)
-        if dmm_math_var.get():
-            value, text = compute_dmm_value(ch_index, volts)
-            sample_value = float("nan") if text == "OVER" else value
-        elif raw_var.get():
-            sample_value = float(raw)
+    try:
+        if position == "End":
+            buffer: deque[tuple[float, float]] = deque(maxlen=n_points)
+            prev_value: float | None = None
+            while True:
+                wait_drdy_fast()
+                raw = read_data_raw_fast()
+                sample_value, trigger_value = compute_capture_values(ch_index, raw)
+                sample_ts = time.time()
+                buffer.append((sample_value, sample_ts))
+                if trigger_value is None:
+                    prev_value = trigger_value
+                    continue
+                if prev_value is None:
+                    prev_value = trigger_value
+                    continue
+                if len(buffer) >= n_points:
+                    if slope == "Rising":
+                        triggered = prev_value < threshold <= trigger_value
+                    else:
+                        triggered = prev_value > threshold >= trigger_value
+                    if triggered:
+                        break
+                prev_value = trigger_value
+            samples = list(buffer)
+            status_var.set("Trigger detected - finalizing benchmark capture...")
         else:
-            sample_value = volts
-        captured[ch_index][idx] = sample_value
-        times[idx] = (time.time() - start) * 1000.0
+            pre_count = n_points // 2
+            if pre_count > 0:
+                pre_buffer: deque[tuple[float, float]] = deque(maxlen=pre_count)
+            else:
+                pre_buffer = deque()
+            prev_value: float | None = None
+            trigger_sample: tuple[float, float] | None = None
+            while True:
+                wait_drdy_fast()
+                raw = read_data_raw_fast()
+                sample_value, trigger_value = compute_capture_values(ch_index, raw)
+                sample_ts = time.time()
+                can_trigger = pre_count == 0 or len(pre_buffer) >= pre_count
+                triggered = False
+                if (
+                    trigger_value is not None
+                    and prev_value is not None
+                    and can_trigger
+                ):
+                    if slope == "Rising":
+                        triggered = prev_value < threshold <= trigger_value
+                    else:
+                        triggered = prev_value > threshold >= trigger_value
+                if triggered:
+                    trigger_sample = (sample_value, sample_ts)
+                    break
+                if pre_count > 0:
+                    pre_buffer.append((sample_value, sample_ts))
+                prev_value = trigger_value
 
-    if gc_was_enabled:
-        gc.enable()
+            status_var.set(
+                "Trigger detected - capturing remaining benchmark samples..."
+            )
+            post_count = n_points - (len(pre_buffer) if pre_count > 0 else 0)
+            samples = list(pre_buffer)
+            post_samples: list[tuple[float, float]] = []
+            if trigger_sample is not None:
+                post_samples.append(trigger_sample)
+            while len(post_samples) < post_count:
+                wait_drdy_fast()
+                raw = read_data_raw_fast()
+                sample_value, _ = compute_capture_values(ch_index, raw)
+                sample_ts = time.time()
+                post_samples.append((sample_value, sample_ts))
+            samples.extend(post_samples)
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+        send_cmd(CMD_SDATAC)
 
-    send_cmd(CMD_SDATAC)
+    captured = {ch_index: [value for value, _ in samples]}
+    if samples:
+        first_time = samples[0][1]
+        times = [(ts - first_time) * 1000.0 for _, ts in samples]
+    else:
+        times = []
     return captured, times
 
 
 def run_multi_capture(
     n_points: int,
-    active_channels: list[int],
+    capture_channels: list[int],
     trigger_index: int,
     threshold: float,
     slope: str,
     armed: bool,
+    position: str,
 ) -> tuple[dict[int, list[float]], list[float]]:
-    if armed:
-        wait_for_trigger(trigger_index, threshold, slope)
-        status_var.set("Trigger detected - capturing multi-channel data...")
-    else:
-        status_var.set("Capturing multi-channel data...")
+    capture_channels = list(capture_channels)
+    capture_set = set(capture_channels)
+    if not capture_channels:
+        return {}, []
 
-    captured = {idx: [] for idx in active_channels}
-    times: list[float] = []
-    start_time: float | None = None
+    scan_channels = capture_channels.copy()
+    if trigger_index in scan_channels:
+        scan_channels.remove(trigger_index)
+    scan_channels.insert(0, trigger_index)
 
-    for _sample_idx in range(n_points):
+    pump_counter = 0
+
+    def pump_events() -> None:
+        nonlocal pump_counter
+        pump_counter += 1
+        if pump_counter >= 50:
+            pump_counter = 0
+            try:
+                root.update_idletasks()
+                root.update()
+            except tk.TclError as exc:
+                raise RuntimeError("Capture interrupted") from exc
+
+    def read_frame() -> tuple[dict[int, float], float | None, float]:
         sample_timestamp = time.time()
-        for idx in active_channels:
-            raw = read_channel_raw(idx)
-            volts = raw_to_volts(raw)
-            if dmm_math_var.get():
-                value, text = compute_dmm_value(idx, volts)
-                sample_value = float("nan") if text == "OVER" else value
-            elif raw_var.get():
-                sample_value = float(raw)
+        frame: dict[int, float] = {}
+        trigger_value: float | None = None
+        for idx in scan_channels:
+            raw_val = read_channel_raw(idx, fast=True)
+            sample_value, trig_value = compute_capture_values(idx, raw_val)
+            if idx in capture_set:
+                frame[idx] = sample_value
+            if idx == trigger_index:
+                trigger_value = trig_value
+        return frame, trigger_value, sample_timestamp
+
+    if not armed or position == "Start":
+        if armed:
+            wait_for_trigger(trigger_index, threshold, slope)
+            status_var.set("Trigger detected - capturing multi-channel data...")
+        else:
+            status_var.set("Capturing multi-channel data...")
+
+        captured = {idx: [] for idx in capture_channels}
+        times: list[float] = []
+        start_time: float | None = None
+
+        gc_was_enabled = gc.isenabled()
+        if gc_was_enabled:
+            gc.disable()
+        try:
+            for _sample_idx in range(n_points):
+                frame, _, sample_timestamp = read_frame()
+                for idx in capture_channels:
+                    captured[idx].append(frame.get(idx, float("nan")))
+                if start_time is None:
+                    start_time = sample_timestamp
+                times.append((sample_timestamp - start_time) * 1000.0)
+                pump_events()
+        finally:
+            if gc_was_enabled:
+                gc.enable()
+
+        return captured, times
+
+    status_var.set(
+        f"Buffering for {position.lower()} trigger on {CHANNEL_MAP[trigger_index][0]}"
+    )
+
+    gc_was_enabled = gc.isenabled()
+    if gc_was_enabled:
+        gc.disable()
+    try:
+        if position == "End":
+            buffer: deque[tuple[dict[int, float], float]] = deque(maxlen=n_points)
+            prev_value: float | None = None
+            while True:
+                frame, trig_value, ts = read_frame()
+                buffer.append((frame, ts))
+                pump_events()
+                if trig_value is None:
+                    prev_value = trig_value
+                    continue
+                if prev_value is None:
+                    prev_value = trig_value
+                    continue
+                if len(buffer) >= n_points:
+                    if slope == "Rising":
+                        triggered = prev_value < threshold <= trig_value
+                    else:
+                        triggered = prev_value > threshold >= trig_value
+                    if triggered:
+                        break
+                prev_value = trig_value
+            frames = list(buffer)
+            status_var.set("Trigger detected - finalizing multi-channel capture...")
+        else:
+            pre_count = n_points // 2
+            if pre_count > 0:
+                pre_buffer: deque[tuple[dict[int, float], float]] = deque(maxlen=pre_count)
             else:
-                sample_value = volts
-            captured[idx].append(sample_value)
-        if start_time is None:
-            start_time = sample_timestamp
-        times.append((sample_timestamp - start_time) * 1000.0)
+                pre_buffer = deque()
+            prev_value: float | None = None
+            trigger_frame: tuple[dict[int, float], float] | None = None
+            while True:
+                frame, trig_value, ts = read_frame()
+                pump_events()
+                can_trigger = pre_count == 0 or len(pre_buffer) >= pre_count
+                triggered = False
+                if (
+                    trig_value is not None
+                    and prev_value is not None
+                    and can_trigger
+                ):
+                    if slope == "Rising":
+                        triggered = prev_value < threshold <= trig_value
+                    else:
+                        triggered = prev_value > threshold >= trig_value
+                if triggered:
+                    trigger_frame = (frame, ts)
+                    break
+                if pre_count > 0:
+                    pre_buffer.append((frame, ts))
+                prev_value = trig_value
+
+            status_var.set(
+                "Trigger detected - capturing remaining multi-channel samples..."
+            )
+            post_count = n_points - (len(pre_buffer) if pre_count > 0 else 0)
+            frames = list(pre_buffer)
+            post_frames: list[tuple[dict[int, float], float]] = []
+            if trigger_frame is not None:
+                post_frames.append(trigger_frame)
+            while len(post_frames) < post_count:
+                frame, _, ts = read_frame()
+                pump_events()
+                post_frames.append((frame, ts))
+            frames.extend(post_frames)
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    captured = {idx: [] for idx in capture_channels}
+    times: list[float] = []
+    if frames:
+        first_time = frames[0][1]
+    else:
+        first_time = None
+    for frame, ts in frames:
+        for idx in capture_channels:
+            captured[idx].append(frame.get(idx, float("nan")))
+        if first_time is None:
+            first_time = ts
+            times.append(0.0)
+        else:
+            times.append((ts - first_time) * 1000.0)
 
     return captured, times
 
@@ -940,18 +1221,19 @@ def perform_capture(armed: bool) -> None:
 
     trigger_label = trigger_channel_var.get()
     trigger_index = CHANNEL_LOOKUP.get(trigger_label, 0)
-    active_channels = [i for i, var in enumerate(channel_vars) if var.get()]
-    if not active_channels:
+    selected_channels = [i for i, var in enumerate(channel_vars) if var.get()]
+    if not selected_channels:
         status_var.set("Select at least one channel")
         return
 
     mode = trigger_mode_var.get()
     slope = trigger_slope_var.get()
+    position = trigger_position_var.get()
 
     if mode == "Benchmark":
-        active_channels = [trigger_index]
-    elif trigger_index not in active_channels:
-        active_channels.insert(0, trigger_index)
+        capture_channels = [trigger_index]
+    else:
+        capture_channels = selected_channels.copy()
 
     is_capturing = True
     arm_button.config(state="disabled")
@@ -963,11 +1245,17 @@ def perform_capture(armed: bool) -> None:
     try:
         if mode == "Benchmark":
             capture, times = run_benchmark_capture(
-                n_points, trigger_index, threshold, slope, armed
+                n_points, trigger_index, threshold, slope, armed, position
             )
         else:
             capture, times = run_multi_capture(
-                n_points, active_channels, trigger_index, threshold, slope, armed
+                n_points,
+                capture_channels,
+                trigger_index,
+                threshold,
+                slope,
+                armed,
+                position,
             )
         captured_data = capture
         timestamps = times
@@ -984,6 +1272,7 @@ def perform_capture(armed: bool) -> None:
         arm_button.config(state="normal")
         capture_button.config(state="normal")
         export_button.config(state="normal")
+        run_pending_calibration()
 
 
 def on_close() -> None:


### PR DESCRIPTION
## Summary
- ensure multi-channel captures only persist the user-selected channels while still sampling the trigger input
- add a fast conversion path and periodic GUI event pumping so multi-mode trigger buffering stays responsive
- reuse the selected channel list when arming multi-mode captures
- issue ADS1256 self-calibration cycles after rate/gain changes or capture runs to stabilise readings

## Testing
- python -m compileall 'Raspberry Pi Project/ADS1256 GUI V3_triggering.py'

------
https://chatgpt.com/codex/tasks/task_e_68ea3d2ca7c883279add8faca088ae86